### PR TITLE
Add `check` target to `Makefile`

### DIFF
--- a/neutral_example_implentation/Makefile
+++ b/neutral_example_implentation/Makefile
@@ -15,5 +15,8 @@ all: opaygo.bin
 opaygo.bin: $(OBJ)
 	$(CC) $^ $(LIBS) -o $@
 
+check: $(OBJ)
+	$(CC) -Werror $^ $(LIBS) -o /dev/null
+
 clean:
 	@rm -f opaygo.bin


### PR DESCRIPTION
This simply checks if the generated source code throws any errors when compiled.